### PR TITLE
Fix: Fixed an issue where the versioning APIs project failed to build

### DIFF
--- a/src/extensions/Riverside.Extensions.Versioning/Riverside.Extensions.Versioning.csproj
+++ b/src/extensions/Riverside.Extensions.Versioning/Riverside.Extensions.Versioning.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.1;net9.0-windows10.0.26100.0;net8.0-windows10.0.22621.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net9.0-windows10.0.26100.0;net8.0-windows10.0.22621.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)' == 'net9.0-windows10.0.26100.0'">

--- a/src/extensions/Riverside.Extensions.Versioning/Version.cs
+++ b/src/extensions/Riverside.Extensions.Versioning/Version.cs
@@ -46,10 +46,12 @@ public struct Version : IEquatable<Version>, IComparable<Version>
         return obj is Version other && Equals(other);
     }
 
+#if !NETSTANDARD2_0
     public override readonly int GetHashCode()
     {
         return HashCode.Combine(Major, Minor, Patch, PreRelease, BuildMetadata);
     }
+#endif
 
     public readonly int CompareTo(Version other)
     {


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

<!--
To prevent extra work, all changes to the codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
-->

- Related #44 

---

<!-- Write a detailed description of your changes here -->

Removes the `GetHashCode()` method in .NET Standard 2.0 because it is not available.
The versioning APIs must be as universal as possible, and fixing issues like this is vital.

The `GetHashCode()` method will be available again after #44 is completed in `v2.0.0-rc2`.