### PR TITLE
Code Quality: Renamed `Cube.UI` to `Riverside.Toolkit`

### DIFF
--- a/src/core/Riverside.Toolkit.Brushes/BackdropKind.cs
+++ b/src/core/Riverside.Toolkit.Brushes/BackdropKind.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Cube.UI.Brushes
+namespace Riverside.Toolkit.Brushes
 {
     public enum BackdropKind
     {

--- a/src/core/Riverside.Toolkit.Brushes/MicaAltBrush.cs
+++ b/src/core/Riverside.Toolkit.Brushes/MicaAltBrush.cs
@@ -6,7 +6,7 @@ using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Windows.ApplicationModel;
 
-namespace Cube.UI.Brushes
+namespace Riverside.Toolkit.Brushes
 {
     public class MicaAltBrush : XamlCompositionBrushBase, INotifyPropertyChanged
     {

--- a/src/core/Riverside.Toolkit.Brushes/MicaBrushes.xaml
+++ b/src/core/Riverside.Toolkit.Brushes/MicaBrushes.xaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:brushes="using:Cube.UI.Brushes"
+    xmlns:brushes="using:Riverside.Toolkit.Brushes"
     xmlns:media="using:Microsoft.Toolkit.Uwp.UI.Media"
     xmlns:mica="using:MicaForUWP.Media">
     <media:BackdropBlurBrush x:Key="MicaBlurBrush" Amount="240" />


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

Looks like in merging legacy CubeKit with the new CubeKit I forgot to replace a couple of the namespaces. These are the last ones for now.
