### PR TITLE
Fix: Fixed an issue where restore would fail because of a corrupt WebView2 build

### DIFF
--- a/eng/Tooling.props
+++ b/eng/Tooling.props
@@ -40,6 +40,7 @@
 		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(IsWinUIProject)' == 'true'">
+		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2957.106" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.26100.1742" />
 		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
 		<PackageReference Include="WinUIEx" Version="2.5.1" />
@@ -62,6 +63,7 @@
 		<IsAotCompatible>true</IsAotCompatible>
 	</PropertyGroup>
 	<ItemGroup Condition="'$(IsUwpProject)' == 'true' ">
+		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2957.106" />
 		<PackageReference Include="Microsoft.UI.Xaml" Version="2.8.6" />
 		<PackageReference Include="Win2D.uwp" Version="1.28.1" />
 		<PackageReference Include="DependencyPropertyGenerator" Version="1.4.0">


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Resolved / Related Issues**

<!--
To prevent extra work, all changes to the codebase must link to an approved issue marked as `Ready to build`. Please insert the issue number following the hashtag with the issue number that this Pull Request resolves.
-->

- Closes #55 

**Steps used to test these changes**

<!--
Stability is a top priority and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.
-->

Changes cannot be tested in the current state; the errors only occur during the NuGet restore process.