### PR TITLE
Code Quality: Added .NET Framework TFMs to WPF projects

### DIFF
--- a/eng/MultiTarget/Wpf/Head.props
+++ b/eng/MultiTarget/Wpf/Head.props
@@ -1,8 +1,8 @@
 <Project>
 	<PropertyGroup>
-		<TargetFrameworks>net8.0-windows;net9.0-windows</TargetFrameworks>
+		<TargetFrameworks>net8.0-windows;net9.0-windows;net481;net462</TargetFrameworks>
 		<UseWPF>true</UseWPF>
-		<IsAotCompatible Condition="'$(TargetFramework)' != 'net462'">true</IsAotCompatible>
+		<IsAotCompatible Condition="'$(TargetFramework)' != 'net481' and '$(TargetFramework)' != 'net462'">true</IsAotCompatible>
 
 		<TargetPlatformVersion>10.0.22621.0</TargetPlatformVersion>
 		<TargetPlatformMinVersion>7.0</TargetPlatformMinVersion>


### PR DESCRIPTION
<!-- 
🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨🚨
I ACKNOWLEDGE THE FOLLOWING BEFORE PROCEEDING:
1. PR may be deleted if it is not following the template
2. Try not to make duplicates. Do a quick search before posting
3. Add a clear title starting with "Feature:" or "Fix:"
-->

**Steps used to test these changes**

<!--
Stability is a top priority and all changes are required to go through testing before being merged into the repo. Please include a list of steps that you used to test this PR.
-->

1. Restored projects
2. Built projects

---

<!-- Write a detailed description of your changes here -->

Adds `net462` and `net481` TFMs to WPF projects (no compatibility for `net452` though due to Riverside.Extensions.PInvoke currently not supporting it #82)